### PR TITLE
Add CSS prefixes for flex classes and resize arrow buttons to be compatible with smaller screens

### DIFF
--- a/dist/less/main.css
+++ b/dist/less/main.css
@@ -118,8 +118,11 @@ body {
 .app {
   width: 100%;
   height: 100%;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-flow: column;
+  -ms-flex-flow: column;
+      flex-flow: column;
 }
 .app .navbar {
   padding: 0 0 0 0.25em;
@@ -136,19 +139,25 @@ body {
   color: #f0c808;
 }
 .app .blank {
-  flex: 2;
+  -webkit-box-flex: 2;
+      -ms-flex: 2;
+          flex: 2;
   overflow: auto;
 }
 .app .log {
   padding: 1em;
-  flex: 2;
+  -webkit-box-flex: 2;
+      -ms-flex: 2;
+          flex: 2;
   overflow: auto;
 }
 .app .log code {
   display: block;
 }
 .app .arrows {
-  flex: 2;
+  -webkit-box-flex: 2;
+      -ms-flex: 2;
+          flex: 2;
   overflow: auto;
   position: relative;
 }
@@ -156,7 +165,8 @@ body {
   position: absolute;
   left: 50%;
   top: 50%;
-  transform: translateY(-50%) translateX(-50%);
+  -webkit-transform: translateY(-50%) translateX(-50%);
+          transform: translateY(-50%) translateX(-50%);
   text-align: center;
   width: 348px;
 }
@@ -172,6 +182,7 @@ body {
   border-radius: 25%;
   color: #fff1d0;
   background-color: #f0c808;
+  -webkit-transition: background-color ease-in 200ms;
   transition: background-color ease-in 200ms;
 }
 .app .arrows .buttons span:hover,
@@ -197,7 +208,8 @@ body {
   background-color: transparent;
 }
 .app .mousepad {
-  flex: 2;
+	display: block;
+	height: 100%;
   overflow: auto;
   position: relative;
 }
@@ -214,7 +226,10 @@ body {
   text-align: center;
 }
 .app .button-toggles span {
-  user-select: none;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
   display: inline-block;
   background-color: #086788;
   border: none;
@@ -228,6 +243,8 @@ body {
   background-color: #fff1d0;
 }
 .app input {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
   min-height: 30px;
   width: 100%;

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -31,13 +31,13 @@ body {
 .app {
   width: 100%;
   height: 100%;
-    display: -webkit-box;
-	display: -ms-flexbox;
-	display: flex;
-	-webkit-box-orient: vertical;
-	-webkit-box-direction: normal;
-	-ms-flex-direction: column;
-	flex-direction: column;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
 
   .navbar {
     padding: 0 0 0 0.25em;
@@ -59,7 +59,7 @@ body {
   .panel() {
     -webkit-box-flex: 2;
     -ms-flex: 2;
-            flex: 2;
+    flex: 2;
   }
 
   .blank {
@@ -86,6 +86,7 @@ body {
       left: 50%;
       top: 50%;
       transform: translateY(-50%) translateX(-50%);
+      -webkit-transform: translateY(-50%) translateX(-50%);
       text-align: center;
       width: @btn-size * 3 + @btn-margin * 6;
 
@@ -102,6 +103,7 @@ body {
         color: @color-btn;
         background-color: @color-active;
         transition: background-color ease-in 200ms;
+        -webkit-transition: background-color ease-in 200ms;
 
         &:hover,
         &:active{
@@ -147,6 +149,9 @@ body {
   .button-toggles {
     text-align: center;
     span {
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
       user-select: none;
       display: inline-block;
       background-color: @color-bg;

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -91,7 +91,7 @@ body {
     @btn-margin: 10px;
 
     .buttons {
-	  width: 100%;
+	  display: inline-block;
       background-color: @color-bg;
 	  .panel();
       text-align: center;

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -31,8 +31,13 @@ body {
 .app {
   width: 100%;
   height: 100%;
-  display: flex;
-  flex-flow: column;
+    display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-orient: vertical;
+	-webkit-box-direction: normal;
+	-ms-flex-direction: column;
+	flex-direction: column;
 
   .navbar {
     padding: 0 0 0 0.25em;
@@ -52,8 +57,9 @@ body {
   }
 
   .panel() {
-    flex: 2;
-    overflow: auto;
+    -webkit-box-flex: 2;
+    -ms-flex: 2;
+            flex: 2;
   }
 
   .blank {
@@ -157,7 +163,9 @@ body {
   }
 
   input {
-    display: flex;
+    display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
     min-height: 30px;
 
     width: 100%;
@@ -176,4 +184,3 @@ body {
     color: @color-fg;
   }
 }
-

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -77,16 +77,23 @@ body {
   .arrows {
     .panel();
     position: relative;
+	display: flex;
+	display: -webkit-box;
+	display: -ms-flexbox;
+	-webkit-box-align: center;
+	-ms-flex-align: center;
+	align-items: center;
+	-webkit-box-pack: center;
+	-ms-flex-pack: center;
+	justify-content: center;
 
-    @btn-size: 96px;
+    @btn-size: 80px;
     @btn-margin: 10px;
 
     .buttons {
-      position: absolute;
-      left: 50%;
-      top: 50%;
-      transform: translateY(-50%) translateX(-50%);
-      -webkit-transform: translateY(-50%) translateX(-50%);
+	  width: 100%;
+      background-color: @color-bg;
+	  .panel();
       text-align: center;
       width: @btn-size * 3 + @btn-margin * 6;
 


### PR DESCRIPTION
Hey,

I've add some CSS prefixes to increase compatibility and reduced from 96px to 80px the arrow buttons to fit on smaller screens such as iPhone 4/4s.
